### PR TITLE
Add ant clearing controls and global update rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# ChatGPT_Output
-Here's where my ChatGPT output goes.
+# Cellular Automata Sandbox (Godot 4.5.1)
+
+This project builds a fullscreen-friendly cellular automata playground designed for shader experimentation. The grid is binary, supports selectable colors, and exposes three stackable automata: Wolfram 1D rules sweeping down the screen, Langton's ants, and Conway's Game of Life (GoL).
+
+## Running
+Open the project in Godot 4.5.1 and play the **Main** scene. The UI is created at runtime, so no additional setup is required.
+The control panel lives on the left to maximize horizontal space for the grid and can be collapsed section-by-section.
+
+## Controls & Features
+- **Grid**
+  - Cell size slider (1–128 px) keeps the grid aligned to the viewport area beside the sidebar; resizing or changing cell size rebuilds the grid.
+  - Global updates-per-second gate (default 1.0) to throttle or stress-test how often automata logic runs per frame.
+  - Edge behavior: Wrap (default), Bounce, or Fall off.
+  - Alive/dead color pickers (default white/black).
+  - Random seeding with adjustable coverage percentage and a clear button that also clears ants.
+- **Playback**
+  - Global Play/Pause toggle plus a single-step button to advance every enabled automaton once while paused.
+- **Wolfram**
+  - Rule selector (0–255), per-second rate (floats allowed), auto toggle, and manual step.
+  - One-click top-row seeds: random fill based on the current seed percentage or a single centered dot, both resetting the Wolfram sweep to the second row.
+  - Sweeps from the top row downward, wrapping when it reaches the bottom.
+- **Langton's Ant**
+  - Spawn any number of ants with a chosen color; supports edge behaviors above.
+  - Dedicated “Clear ants” action to remove all walkers when needed.
+  - Per-second rate, auto toggle, and manual step.
+- **Game of Life**
+  - Per-second rate (float), auto toggle, and manual step.
+  - Can chain to ants: set “Every N ant steps” to fire a GoL sweep after that many ant updates (e.g., 100).
+
+## Suggested Workflow
+1. Set a Wolfram rule and speed to seed the grid from the top.
+2. Spawn dozens of ants (default red) and let them roam/modify the pattern.
+3. Configure GoL to trigger automatically every N ant steps while also running on its own cadence if desired.
+
+You can experiment with extreme update rates (e.g., 0.001 or 100.0 steps/sec) to mix slow sweeps with rapid updates.

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -1,514 +1,670 @@
+@icon("res://icon.svg")
+class_name CellularAutomataHub
 extends Control
 
-const PRICE_STEP: float = 0.05
-const MIN_PRICE: float = 0.05
-const MAX_PRICE: float = 2.0
+const DIRS: Array[Vector2i] = [Vector2i.UP, Vector2i.RIGHT, Vector2i.DOWN, Vector2i.LEFT]
+const EDGE_WRAP := 0
+const EDGE_BOUNCE := 1
+const EDGE_FALLOFF := 2
 
-const WIRE_BUNDLE: int = 1000
-const WIRE_BASE_COST: float = 15.0
-const AUTOCLIPPER_BASE_COST: float = 12.0
-const MARKETING_BASE_COST: float = 100.0
-const AUTOCLIPPER_RATE: float = 1.0
+var cell_size: int = 1
+var grid_size: Vector2i
+var grid: PackedByteArray = PackedByteArray()
 
-const PROCESSOR_BASE_COST: float = 40.0
-const MEMORY_BASE_COST: float = 60.0
-const OPS_PER_PROCESSOR: float = 0.35
-const OPS_MEMORY_FACTOR: float = 0.15
-const BASE_OPS_CAPACITY: int = 50
-const AUTOCLIPPER_UNLOCK: int = 100
-const COMPUTING_UNLOCK: int = 2000
-const UPGRADE_KEYS: Array[String] = [
-    "analytics_1",
-    "analytics_2",
-    "analytics_3",
-    "efficiency_1",
-    "efficiency_2",
-    "efficiency_3",
-    "bulk_wire_1",
-    "bulk_wire_2",
-    "marketing_insight_1",
-    "marketing_insight_2",
-    "price_optimizer",
-    "processor_boost",
-    "memory_boost"
-]
+var alive_color: Color = Color.WHITE
+var dead_color: Color = Color.BLACK
 
-class Upgrade:
-    var key: String
-    var label: String
-    var description: String
-    var ops_cost: int
-    var effect: Callable
-    var unlock_at_clips: int
-    var prerequisite: String
-    var applied: bool = false
+var edge_mode: int = EDGE_WRAP
 
-var total_paperclips: int = 0
-var total_sold: int = 0
-var unsold_inventory: int = 0
-var funds: float = 0.0
-var wire: int = 1000
-var price: float = 0.25
-var marketing_level: int = 0
-var marketing_cost: float = MARKETING_BASE_COST
-var autoclippers: int = 0
-var autoclipper_cost: float = AUTOCLIPPER_BASE_COST
+var wolfram_rule: int = 110
+var wolfram_row: int = 0
+var wolfram_rate: float = 1.0
+var wolfram_accumulator: float = 0.0
+var wolfram_enabled: bool = true
 
-var production_accumulator: float = 0.0
-var sales_accumulator: float = 0.0
-var demand_buffer: float = 0.0
-var smoothed_demand: float = 0.0
+var ant_rate: float = 1.0
+var ant_accumulator: float = 0.0
+var ants_enabled: bool = true
 
-var processors: int = 1
-var memory_banks: int = 1
-var operations: float = 0.0
-var ops_capacity: int = BASE_OPS_CAPACITY
-var processor_cost: float = PROCESSOR_BASE_COST
-var memory_cost: float = MEMORY_BASE_COST
+var gol_rate: float = 0.01
+var gol_accumulator: float = 0.0
+var gol_enabled: bool = true
+var gol_every_ant_steps: int = 100
 
-var demand_bonus: float = 0.0
-var clipper_rate_bonus: float = 0.0
-var wire_per_purchase: int = WIRE_BUNDLE
-var marketing_discount: float = 0.0
-var ops_rate_bonus: float = 0.0
-var ops_capacity_bonus: int = 0
-var price_sensitivity: float = 1.0
+var ants: Array[Vector2i] = []
+var ant_directions: Array[int] = []
+var ant_colors: Array[Color] = []
+var ant_step_counter: int = 0
 
-var labels: Dictionary[String, Label] = {}
-var buttons: Dictionary[String, Button] = {}
-var upgrade_buttons: Dictionary[String, Button] = {}
-var upgrades: Array[Upgrade] = []
+var seed_fill: float = 0.5
 
-var computing_panel: VBoxContainer
+var global_rate: float = 1.0
+var global_accumulator: float = 0.0
+
+var ui_ready: bool = false
+var is_paused: bool = false
+
+var step_requested: bool = false
+
+@onready var grid_view: TextureRect = TextureRect.new()
+@onready var info_label: Label = Label.new()
+@onready var view_container: Panel = Panel.new()
+
+@onready var wolfram_rate_spin: SpinBox = SpinBox.new()
+@onready var ant_rate_spin: SpinBox = SpinBox.new()
+@onready var gol_rate_spin: SpinBox = SpinBox.new()
+@onready var gol_every_spin: SpinBox = SpinBox.new()
+@onready var cell_size_spin: SpinBox = SpinBox.new()
+@onready var rule_spin: SpinBox = SpinBox.new()
+@onready var edge_option: OptionButton = OptionButton.new()
+@onready var alive_picker: ColorPickerButton = ColorPickerButton.new()
+@onready var dead_picker: ColorPickerButton = ColorPickerButton.new()
+@onready var ant_color_picker: ColorPickerButton = ColorPickerButton.new()
+@onready var ant_count_spin: SpinBox = SpinBox.new()
+@onready var fill_spin: SpinBox = SpinBox.new()
 
 func _ready() -> void:
+    set_process(true)
     build_ui()
-    setup_upgrades()
-    update_ops_capacity()
-    smoothed_demand = calculate_target_demand()
-    refresh_ui()
+    update_grid_size()
+    random_fill_grid()
+    render_grid()
 
 func build_ui() -> void:
-    var margin: MarginContainer = MarginContainer.new()
-    margin.set_anchors_preset(Control.PRESET_FULL_RECT)
-    margin.offset_left = 32
-    margin.offset_top = 20
-    margin.offset_right = -32
-    margin.offset_bottom = -20
-    add_child(margin)
+    var root := HBoxContainer.new()
+    root.set_anchors_preset(Control.PRESET_FULL_RECT)
+    root.add_theme_constant_override("separation", 8)
+    add_child(root)
 
-    var root: VBoxContainer = VBoxContainer.new()
-    root.add_theme_constant_override("separation", 14)
-    margin.add_child(root)
+    var sidebar := PanelContainer.new()
+    sidebar.custom_minimum_size = Vector2(260, 0)
+    sidebar.size_flags_horizontal = Control.SIZE_FILL
+    sidebar.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    root.add_child(sidebar)
 
-    var title: Label = Label.new()
-    title.text = "Universal Paperclips"
-    title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-    title.add_theme_font_size_override("font_size", 28)
-    root.add_child(title)
+    var sidebar_layout := VBoxContainer.new()
+    sidebar_layout.add_theme_constant_override("separation", 10)
+    sidebar.add_child(sidebar_layout)
 
-    var content_row: HBoxContainer = HBoxContainer.new()
-    content_row.add_theme_constant_override("separation", 20)
-    content_row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-    content_row.size_flags_vertical = Control.SIZE_EXPAND_FILL
-    root.add_child(content_row)
+    var title := Label.new()
+    title.text = "Shader-friendly Cellular Automata"
+    title.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+    title.add_theme_font_size_override("font_size", 18)
+    sidebar_layout.add_child(title)
 
-    var left_column: VBoxContainer = VBoxContainer.new()
-    left_column.add_theme_constant_override("separation", 12)
-    left_column.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-    left_column.size_flags_vertical = Control.SIZE_EXPAND_FILL
-    content_row.add_child(left_column)
+    var info_row := HBoxContainer.new()
+    info_row.add_theme_constant_override("separation", 6)
+    sidebar_layout.add_child(info_row)
 
-    var stats_box: GridContainer = GridContainer.new()
-    stats_box.columns = 2
-    stats_box.add_theme_constant_override("h_separation", 12)
-    stats_box.add_theme_constant_override("v_separation", 6)
-    left_column.add_child(stats_box)
+    info_label.text = "Grid ready"
+    info_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+    info_row.add_child(info_label)
 
-    add_stat_row(stats_box, "Clips made", "total")
-    add_stat_row(stats_box, "Unsold inventory", "inventory")
-    add_stat_row(stats_box, "Clip price", "price")
-    add_stat_row(stats_box, "Funds", "funds")
-    add_stat_row(stats_box, "Wire", "wire")
-    add_stat_row(stats_box, "Clips / second", "production")
-    add_stat_row(stats_box, "Marketing level", "marketing")
-    add_stat_row(stats_box, "AutoClippers", "autoclippers")
+    var play_button := Button.new()
+    play_button.text = "Pause"
+    play_button.pressed.connect(func():
+        is_paused = !is_paused
+        play_button.text = "Play" if is_paused else "Pause"
+    )
+    info_row.add_child(play_button)
 
-    var make_row: HBoxContainer = HBoxContainer.new()
-    make_row.add_theme_constant_override("separation", 8)
-    left_column.add_child(make_row)
+    var step_button := Button.new()
+    step_button.text = "Step"
+    step_button.pressed.connect(func():
+        step_requested = true
+    )
+    info_row.add_child(step_button)
 
-    var make_button: Button = Button.new()
-    make_button.text = "Make paperclip"
-    make_button.pressed.connect(_on_make_clip_pressed)
-    buttons["make"] = make_button
-    make_row.add_child(make_button)
+    var scroll := ScrollContainer.new()
+    scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    sidebar_layout.add_child(scroll)
 
-    var auto_button: Button = Button.new()
-    auto_button.pressed.connect(_on_buy_autoclipper_pressed)
-    auto_button.visible = false
-    buttons["autoclipper"] = auto_button
-    make_row.add_child(auto_button)
+    var controls_column := VBoxContainer.new()
+    controls_column.add_theme_constant_override("separation", 8)
+    scroll.add_child(controls_column)
 
-    var wire_button: Button = Button.new()
-    wire_button.pressed.connect(_on_buy_wire_pressed)
-    buttons["wire"] = wire_button
-    make_row.add_child(wire_button)
+    controls_column.add_child(build_collapsible_section("Grid", build_grid_controls()))
+    controls_column.add_child(build_collapsible_section("Wolfram", build_wolfram_controls()))
+    controls_column.add_child(build_collapsible_section("Langton's Ant", build_ant_controls()))
+    controls_column.add_child(build_collapsible_section("Game of Life", build_gol_controls()))
 
-    var price_box: HBoxContainer = HBoxContainer.new()
-    price_box.alignment = BoxContainer.ALIGNMENT_CENTER
-    price_box.add_theme_constant_override("separation", 6)
-    left_column.add_child(price_box)
+    view_container = Panel.new()
+    view_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    view_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    view_container.custom_minimum_size = Vector2(200, 200)
+    root.add_child(view_container)
 
-    var price_label: Label = Label.new()
-    price_label.text = "Adjust price"
-    price_box.add_child(price_label)
+    grid_view.stretch_mode = TextureRect.STRETCH_SCALE
+    grid_view.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+    grid_view.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    grid_view.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    grid_view.set_anchors_preset(Control.PRESET_FULL_RECT)
+    grid_view.modulate = Color.WHITE
+    view_container.add_child(grid_view)
 
-    var minus_button: Button = Button.new()
-    minus_button.text = "-"
-    minus_button.focus_mode = Control.FOCUS_NONE
-    minus_button.custom_minimum_size = Vector2(38, 28)
-    minus_button.pressed.connect(func(): adjust_price(-PRICE_STEP))
-    buttons["price_down"] = minus_button
-    price_box.add_child(minus_button)
+    ui_ready = true
 
-    var plus_button: Button = Button.new()
-    plus_button.text = "+"
-    plus_button.focus_mode = Control.FOCUS_NONE
-    plus_button.custom_minimum_size = Vector2(38, 28)
-    plus_button.pressed.connect(func(): adjust_price(PRICE_STEP))
-    buttons["price_up"] = plus_button
-    price_box.add_child(plus_button)
+func build_collapsible_section(title: String, content: Control) -> VBoxContainer:
+    var wrapper := VBoxContainer.new()
+    wrapper.add_theme_constant_override("separation", 4)
 
-    var marketing_row: HBoxContainer = HBoxContainer.new()
-    marketing_row.add_theme_constant_override("separation", 8)
-    left_column.add_child(marketing_row)
+    var header := Button.new()
+    header.text = title
+    header.toggle_mode = true
+    header.button_pressed = true
+    wrapper.add_child(header)
 
-    var marketing_button: Button = Button.new()
-    marketing_button.pressed.connect(_on_buy_marketing_pressed)
-    buttons["marketing"] = marketing_button
-    marketing_row.add_child(marketing_button)
+    var holder := VBoxContainer.new()
+    holder.add_theme_constant_override("separation", 6)
+    holder.add_child(content)
+    wrapper.add_child(holder)
 
-    var demand_label: Label = Label.new()
-    demand_label.text = "Demand: -- clips / sec"
-    labels["demand"] = demand_label
-    marketing_row.add_child(demand_label)
+    header.toggled.connect(func(pressed):
+        holder.visible = pressed
+    )
 
-    computing_panel = VBoxContainer.new()
-    computing_panel.add_theme_constant_override("separation", 6)
-    computing_panel.visible = false
-    left_column.add_child(computing_panel)
+    return wrapper
 
-    var computing_title: Label = Label.new()
-    computing_title.text = "Computing"
-    computing_title.add_theme_font_size_override("font_size", 18)
-    computing_panel.add_child(computing_title)
+func build_grid_controls() -> VBoxContainer:
+    var box := VBoxContainer.new()
+    box.add_theme_constant_override("separation", 6)
 
-    add_simple_row(computing_panel, "Processors", "processors")
-    add_simple_row(computing_panel, "Memory", "memory")
-    add_simple_row(computing_panel, "Operations", "ops")
+    var size_row := HBoxContainer.new()
+    var size_label := Label.new()
+    size_label.text = "Cell size"
+    size_row.add_child(size_label)
+    cell_size_spin.min_value = 1
+    cell_size_spin.max_value = 128
+    cell_size_spin.value = cell_size
+    cell_size_spin.step = 1
+    cell_size_spin.value_changed.connect(func(value):
+        cell_size = int(value)
+        update_grid_size()
+        render_grid()
+    )
+    size_row.add_child(cell_size_spin)
+    box.add_child(size_row)
 
-    var computing_buttons: HBoxContainer = HBoxContainer.new()
-    computing_buttons.add_theme_constant_override("separation", 8)
-    computing_panel.add_child(computing_buttons)
+    var global_rate_row := HBoxContainer.new()
+    var global_rate_label := Label.new()
+    global_rate_label.text = "Updates/sec"
+    global_rate_row.add_child(global_rate_label)
+    var global_rate_spin := SpinBox.new()
+    global_rate_spin.min_value = 0.0
+    global_rate_spin.max_value = 5000.0
+    global_rate_spin.step = 0.1
+    global_rate_spin.allow_greater = true
+    global_rate_spin.value = global_rate
+    global_rate_spin.value_changed.connect(func(v): global_rate = max(0.0, v))
+    global_rate_row.add_child(global_rate_spin)
+    box.add_child(global_rate_row)
 
-    var buy_processor_button: Button = Button.new()
-    buy_processor_button.pressed.connect(_on_buy_processor_pressed)
-    buttons["processor"] = buy_processor_button
-    computing_buttons.add_child(buy_processor_button)
+    var edge_row := HBoxContainer.new()
+    var edge_label := Label.new()
+    edge_label.text = "Edges"
+    edge_row.add_child(edge_label)
+    edge_option.add_item("Wrap", EDGE_WRAP)
+    edge_option.add_item("Bounce", EDGE_BOUNCE)
+    edge_option.add_item("Fall off", EDGE_FALLOFF)
+    edge_option.selected = EDGE_WRAP
+    edge_option.item_selected.connect(func(index): edge_mode = index)
+    edge_row.add_child(edge_option)
+    box.add_child(edge_row)
 
-    var buy_memory_button: Button = Button.new()
-    buy_memory_button.pressed.connect(_on_buy_memory_pressed)
-    buttons["memory"] = buy_memory_button
-    computing_buttons.add_child(buy_memory_button)
+    var color_row := HBoxContainer.new()
+    var color_label := Label.new()
+    color_label.text = "Alive / Dead"
+    color_row.add_child(color_label)
+    alive_picker.color = alive_color
+    alive_picker.color_changed.connect(func(c): alive_color = c; render_grid())
+    dead_picker.color = dead_color
+    dead_picker.color_changed.connect(func(c): dead_color = c; render_grid())
+    color_row.add_child(alive_picker)
+    color_row.add_child(dead_picker)
+    box.add_child(color_row)
 
-    var log_label: Label = Label.new()
-    log_label.text = "First phase: build clips, manage wire, set prices, invest in computing, and buy marketing, AutoClippers, and upgrades."
-    log_label.autowrap_mode = TextServer.AUTOWRAP_WORD
-    left_column.add_child(log_label)
+    var fill_row := HBoxContainer.new()
+    var fill_label := Label.new()
+    fill_label.text = "Seed %"
+    fill_row.add_child(fill_label)
+    fill_spin.min_value = 0
+    fill_spin.max_value = 100
+    fill_spin.step = 1
+    fill_spin.value = seed_fill * 100.0
+    fill_spin.value_changed.connect(func(v): seed_fill = float(v) / 100.0)
+    fill_row.add_child(fill_spin)
+    var seed_button := Button.new()
+    seed_button.text = "Randomize"
+    seed_button.pressed.connect(func(): random_fill_grid(); render_grid())
+    fill_row.add_child(seed_button)
+    box.add_child(fill_row)
 
-    var right_column: VBoxContainer = VBoxContainer.new()
-    right_column.add_theme_constant_override("separation", 10)
-    right_column.size_flags_horizontal = Control.SIZE_FILL
-    right_column.size_flags_vertical = Control.SIZE_EXPAND_FILL
-    content_row.add_child(right_column)
+    var clear_button := Button.new()
+    clear_button.text = "Clear"
+    clear_button.pressed.connect(func():
+        grid.fill(0)
+        clear_ants()
+        render_grid()
+    )
+    box.add_child(clear_button)
 
-    var upgrade_panel: VBoxContainer = VBoxContainer.new()
-    upgrade_panel.add_theme_constant_override("separation", 6)
-    upgrade_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
-    right_column.add_child(upgrade_panel)
+    return box
 
-    var upgrade_title: Label = Label.new()
-    upgrade_title.text = "Upgrades"
-    upgrade_title.add_theme_font_size_override("font_size", 18)
-    upgrade_panel.add_child(upgrade_title)
+func build_wolfram_controls() -> VBoxContainer:
+    var box := VBoxContainer.new()
+    box.add_theme_constant_override("separation", 6)
 
-    var upgrade_scroll: ScrollContainer = ScrollContainer.new()
-    upgrade_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-    upgrade_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
-    upgrade_scroll.custom_minimum_size = Vector2(360, 420)
-    upgrade_panel.add_child(upgrade_scroll)
+    var rule_row := HBoxContainer.new()
+    var rule_label := Label.new()
+    rule_label.text = "Rule"
+    rule_row.add_child(rule_label)
+    rule_spin.min_value = 0
+    rule_spin.max_value = 255
+    rule_spin.value = wolfram_rule
+    rule_spin.value_changed.connect(func(v): wolfram_rule = int(v))
+    rule_row.add_child(rule_spin)
+    box.add_child(rule_row)
 
-    var upgrade_container: VBoxContainer = VBoxContainer.new()
-    upgrade_container.add_theme_constant_override("separation", 6)
-    upgrade_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-    upgrade_scroll.add_child(upgrade_container)
-    for key: String in UPGRADE_KEYS:
-        var button: Button = Button.new()
-        upgrade_buttons[key] = button
-        button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-        button.pressed.connect(func(): _on_upgrade_pressed(key))
-        upgrade_container.add_child(button)
+    var rate_row := HBoxContainer.new()
+    var rate_label := Label.new()
+    rate_label.text = "Steps/sec"
+    rate_row.add_child(rate_label)
+    wolfram_rate_spin.min_value = 0.0
+    wolfram_rate_spin.max_value = 200.0
+    wolfram_rate_spin.step = 0.01
+    wolfram_rate_spin.value = wolfram_rate
+    wolfram_rate_spin.allow_greater = true
+    wolfram_rate_spin.value_changed.connect(func(v): wolfram_rate = max(0.0, v))
+    rate_row.add_child(wolfram_rate_spin)
+    box.add_child(rate_row)
 
-func add_stat_row(container: GridContainer, title: String, key: String) -> void:
-    var label: Label = Label.new()
-    label.text = title
-    container.add_child(label)
+    var buttons := HBoxContainer.new()
+    var toggle := CheckBox.new()
+    toggle.text = "Auto"
+    toggle.button_pressed = wolfram_enabled
+    toggle.toggled.connect(func(v): wolfram_enabled = v)
+    buttons.add_child(toggle)
+    var step := Button.new()
+    step.text = "Step"
+    step.pressed.connect(func(): step_wolfram(); render_grid())
+    buttons.add_child(step)
+    box.add_child(buttons)
 
-    var value: Label = Label.new()
-    value.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-    labels[key] = value
-    container.add_child(value)
+    var seed_row := HBoxContainer.new()
+    var random_seed := Button.new()
+    random_seed.text = "Seed top row"
+    random_seed.pressed.connect(func(): seed_wolfram_row(true); render_grid())
+    seed_row.add_child(random_seed)
+    var center_seed := Button.new()
+    center_seed.text = "Center dot"
+    center_seed.pressed.connect(func(): seed_wolfram_row(false); render_grid())
+    seed_row.add_child(center_seed)
+    box.add_child(seed_row)
 
-func add_simple_row(container: VBoxContainer, title: String, key: String) -> void:
-    var row: HBoxContainer = HBoxContainer.new()
-    row.add_theme_constant_override("separation", 6)
-    container.add_child(row)
+    return box
 
-    var label: Label = Label.new()
-    label.text = title
-    row.add_child(label)
+func build_ant_controls() -> VBoxContainer:
+    var box := VBoxContainer.new()
+    box.add_theme_constant_override("separation", 6)
 
-    var value: Label = Label.new()
-    value.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-    value.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-    labels[key] = value
-    row.add_child(value)
+    var count_row := HBoxContainer.new()
+    var count_label := Label.new()
+    count_label.text = "Ants"
+    count_row.add_child(count_label)
+    ant_count_spin.min_value = 1
+    ant_count_spin.max_value = 200
+    ant_count_spin.value = 10
+    count_row.add_child(ant_count_spin)
+    ant_color_picker.color = Color(1, 0, 0)
+    count_row.add_child(ant_color_picker)
+    var spawn := Button.new()
+    spawn.text = "Spawn"
+    spawn.pressed.connect(func(): spawn_ants(int(ant_count_spin.value), ant_color_picker.color))
+    count_row.add_child(spawn)
+    box.add_child(count_row)
 
-func setup_upgrades() -> void:
-    upgrades.append_array([
-        create_upgrade("analytics_1", "Sales analytics I", "+0.15 base demand", 120, 2000, "", func(): demand_bonus += 0.15),
-        create_upgrade("analytics_2", "Sales analytics II", "+0.20 base demand", 220, 25000, "analytics_1", func(): demand_bonus += 0.2),
-        create_upgrade("analytics_3", "Sales analytics III", "+0.25 base demand", 320, 150000, "analytics_2", func(): demand_bonus += 0.25),
-        create_upgrade("efficiency_1", "Clipper efficiency I", "+10% AutoClipper speed", 180, 10000, "", func(): clipper_rate_bonus += 0.1),
-        create_upgrade("efficiency_2", "Clipper efficiency II", "+12% AutoClipper speed", 260, 125000, "efficiency_1", func(): clipper_rate_bonus += 0.12),
-        create_upgrade("efficiency_3", "Clipper efficiency III", "+15% AutoClipper speed", 360, 750000, "efficiency_2", func(): clipper_rate_bonus += 0.15),
-        create_upgrade("bulk_wire_1", "Bulk wire spool I", "+250 wire per purchase", 150, 6000, "", func(): wire_per_purchase += 250),
-        create_upgrade("bulk_wire_2", "Bulk wire spool II", "+500 wire per purchase", 240, 110000, "bulk_wire_1", func(): wire_per_purchase += 500),
-        create_upgrade("marketing_insight_1", "Marketing insight I", "-10% marketing costs", 200, 12000, "", func(): marketing_discount += 0.1),
-        create_upgrade("marketing_insight_2", "Marketing insight II", "-12% marketing costs", 320, 200000, "marketing_insight_1", func(): marketing_discount += 0.12),
-        create_upgrade("price_optimizer", "Price optimizer", "Price shifts reduce demand less", 280, 1500000, "marketing_insight_2", Callable(self, "apply_price_optimizer")),
-        create_upgrade("processor_boost", "Processor boost", "+15% ops/sec", 240, 50000, "", func(): ops_rate_bonus += 0.15),
-        create_upgrade("memory_boost", "Memory boost", "+20 ops capacity", 210, 90000, "", Callable(self, "apply_memory_boost"))
-    ])
+    var rate_row := HBoxContainer.new()
+    var rate_label := Label.new()
+    rate_label.text = "Steps/sec"
+    rate_row.add_child(rate_label)
+    ant_rate_spin.min_value = 0.0
+    ant_rate_spin.max_value = 500.0
+    ant_rate_spin.step = 0.01
+    ant_rate_spin.value = ant_rate
+    ant_rate_spin.allow_greater = true
+    ant_rate_spin.value_changed.connect(func(v): ant_rate = max(0.0, v))
+    rate_row.add_child(ant_rate_spin)
+    box.add_child(rate_row)
 
-func apply_price_optimizer() -> void:
-    price_sensitivity = max(0.6, price_sensitivity - 0.15)
-    demand_bonus += 0.05
+    var buttons := HBoxContainer.new()
+    var toggle := CheckBox.new()
+    toggle.text = "Auto"
+    toggle.button_pressed = ants_enabled
+    toggle.toggled.connect(func(v): ants_enabled = v)
+    buttons.add_child(toggle)
+    var step := Button.new()
+    step.text = "Step"
+    step.pressed.connect(func(): step_ants(); render_grid())
+    buttons.add_child(step)
+    box.add_child(buttons)
 
-func apply_memory_boost() -> void:
-    ops_capacity_bonus += 20
-    update_ops_capacity()
+    var clear_row := HBoxContainer.new()
+    var clear_button := Button.new()
+    clear_button.text = "Clear ants"
+    clear_button.pressed.connect(func(): clear_ants(); render_grid())
+    clear_row.add_child(clear_button)
+    box.add_child(clear_row)
 
-func create_upgrade(key: String, label: String, description: String, ops_cost: int, unlock_at_clips: int, prerequisite: String, effect: Callable) -> Upgrade:
-    var upgrade: Upgrade = Upgrade.new()
-    upgrade.key = key
-    upgrade.label = label
-    upgrade.description = description
-    upgrade.ops_cost = ops_cost
-    upgrade.effect = effect
-    upgrade.unlock_at_clips = unlock_at_clips
-    upgrade.prerequisite = prerequisite
-    return upgrade
+    return box
+
+func build_gol_controls() -> VBoxContainer:
+    var box := VBoxContainer.new()
+    box.add_theme_constant_override("separation", 6)
+
+    var rate_row := HBoxContainer.new()
+    var rate_label := Label.new()
+    rate_label.text = "Steps/sec"
+    rate_row.add_child(rate_label)
+    gol_rate_spin.min_value = 0.0
+    gol_rate_spin.max_value = 120.0
+    gol_rate_spin.step = 0.001
+    gol_rate_spin.value = gol_rate
+    gol_rate_spin.allow_greater = true
+    gol_rate_spin.value_changed.connect(func(v): gol_rate = max(0.0, v))
+    rate_row.add_child(gol_rate_spin)
+    box.add_child(rate_row)
+
+    var chain_row := HBoxContainer.new()
+    var chain_label := Label.new()
+    chain_label.text = "Every N ant steps"
+    chain_row.add_child(chain_label)
+    gol_every_spin.min_value = 1
+    gol_every_spin.max_value = 10000
+    gol_every_spin.step = 1
+    gol_every_spin.value = gol_every_ant_steps
+    gol_every_spin.value_changed.connect(func(v): gol_every_ant_steps = int(v))
+    chain_row.add_child(gol_every_spin)
+    box.add_child(chain_row)
+
+    var buttons := HBoxContainer.new()
+    var toggle := CheckBox.new()
+    toggle.text = "Auto"
+    toggle.button_pressed = gol_enabled
+    toggle.toggled.connect(func(v): gol_enabled = v)
+    buttons.add_child(toggle)
+    var step := Button.new()
+    step.text = "Step"
+    step.pressed.connect(func(): step_game_of_life(); render_grid())
+    buttons.add_child(step)
+    box.add_child(buttons)
+
+    return box
+
+func update_grid_size() -> void:
+    if not ui_ready:
+        return
+    var viewport_size: Vector2i = view_container.get_rect().size if view_container != null else get_viewport_rect().size
+    if viewport_size.x <= 0 or viewport_size.y <= 0:
+        viewport_size = get_viewport_rect().size
+    if viewport_size.x <= 0 or viewport_size.y <= 0:
+        return
+    var new_size := Vector2i(max(1, viewport_size.x / cell_size), max(1, viewport_size.y / cell_size))
+    var size_changed := new_size != grid_size or grid.size() != new_size.x * new_size.y
+    grid_size = new_size
+
+    if size_changed:
+        grid.resize(grid_size.x * grid_size.y)
+        grid.fill(0)
+        wolfram_row = 0
+        clear_ants()
+    info_label.text = "Grid: %dx%d cells @ %d px" % [grid_size.x, grid_size.y, cell_size]
+
+func random_fill_grid() -> void:
+    var rng := RandomNumberGenerator.new()
+    rng.randomize()
+    for i in range(grid.size()):
+        if rng.randf() < seed_fill:
+            grid[i] = 1
+        else:
+            grid[i] = 0
+    wolfram_row = 0
+
+func seed_wolfram_row(randomize: bool) -> void:
+    var rng := RandomNumberGenerator.new()
+    rng.randomize()
+    grid.fill(0)
+    var top_row := 0
+    for x in range(grid_size.x):
+        var idx := top_row * grid_size.x + x
+        grid[idx] = 1 if (randomize and rng.randf() < seed_fill) else 0
+    if not randomize and grid_size.x > 0:
+        var center := grid_size.x / 2
+        grid[top_row * grid_size.x + center] = 1
+    wolfram_row = 1
+
+func spawn_ants(count: int, color: Color) -> void:
+    var rng := RandomNumberGenerator.new()
+    rng.randomize()
+    for i in range(count):
+        ants.append(Vector2i(rng.randi_range(0, grid_size.x - 1), rng.randi_range(0, grid_size.y - 1)))
+        ant_directions.append(rng.randi_range(0, DIRS.size() - 1))
+        ant_colors.append(color)
+    render_grid()
+
+func clear_ants() -> void:
+    ants.clear()
+    ant_directions.clear()
+    ant_colors.clear()
+    ant_step_counter = 0
+
+func wrap_position(pos: Vector2i) -> Vector2i:
+    return Vector2i(posmod(pos.x, grid_size.x), posmod(pos.y, grid_size.y))
+
+func sample_cell(pos: Vector2i) -> int:
+    if pos.x >= 0 and pos.x < grid_size.x and pos.y >= 0 and pos.y < grid_size.y:
+        return grid[pos.y * grid_size.x + pos.x]
+
+    match edge_mode:
+        EDGE_WRAP:
+            pos = wrap_position(pos)
+            return grid[pos.y * grid_size.x + pos.x]
+        EDGE_BOUNCE:
+            var bounce_pos := pos
+            if bounce_pos.x < 0:
+                bounce_pos.x = -bounce_pos.x - 1
+            elif bounce_pos.x >= grid_size.x:
+                bounce_pos.x = grid_size.x - (bounce_pos.x - grid_size.x) - 1
+            if bounce_pos.y < 0:
+                bounce_pos.y = -bounce_pos.y - 1
+            elif bounce_pos.y >= grid_size.y:
+                bounce_pos.y = grid_size.y - (bounce_pos.y - grid_size.y) - 1
+            bounce_pos.x = clamp(bounce_pos.x, 0, grid_size.x - 1)
+            bounce_pos.y = clamp(bounce_pos.y, 0, grid_size.y - 1)
+            return grid[bounce_pos.y * grid_size.x + bounce_pos.x]
+        EDGE_FALLOFF:
+            return 0
+    return 0
+
+func set_cell(pos: Vector2i, value: int) -> void:
+    if pos.x < 0 or pos.x >= grid_size.x or pos.y < 0 or pos.y >= grid_size.y:
+        return
+    grid[pos.y * grid_size.x + pos.x] = clamp(value, 0, 1)
+
+func process_wolfram(delta: float) -> bool:
+    if not wolfram_enabled or wolfram_rate <= 0.0:
+        return false
+    wolfram_accumulator += delta
+    var interval := 1.0 / wolfram_rate
+    var stepped := false
+    while wolfram_accumulator >= interval:
+        step_wolfram()
+        wolfram_accumulator -= interval
+        stepped = true
+    return stepped
+
+func process_ants(delta: float) -> bool:
+    if not ants_enabled or ant_rate <= 0.0:
+        return false
+    ant_accumulator += delta
+    var interval := 1.0 / ant_rate
+    var stepped := false
+    while ant_accumulator >= interval:
+        step_ants()
+        ant_accumulator -= interval
+        stepped = true
+    return stepped
+
+func process_game_of_life(delta: float) -> bool:
+    if not gol_enabled or gol_rate <= 0.0:
+        return false
+    gol_accumulator += delta
+    var interval := 1.0 / gol_rate
+    var stepped := false
+    while gol_accumulator >= interval:
+        step_game_of_life()
+        gol_accumulator -= interval
+        stepped = true
+    return stepped
+
+func step_wolfram() -> void:
+    var source_row := (wolfram_row - 1 + grid_size.y) % grid_size.y
+    for x in range(grid_size.x):
+        var left := sample_cell(Vector2i(x - 1, source_row))
+        var center := sample_cell(Vector2i(x, source_row))
+        var right := sample_cell(Vector2i(x + 1, source_row))
+        var key := (left << 2) | (center << 1) | right
+        var state := (wolfram_rule >> key) & 1
+        set_cell(Vector2i(x, wolfram_row), state)
+    wolfram_row = (wolfram_row + 1) % grid_size.y
+
+func step_ants() -> void:
+    var remove_indices: Array[int] = []
+    for i in range(ants.size()):
+        var pos := ants[i]
+        if pos.x < 0 or pos.x >= grid_size.x or pos.y < 0 or pos.y >= grid_size.y:
+            remove_indices.append(i)
+            continue
+
+        var idx := pos.y * grid_size.x + pos.x
+        var current := grid[idx]
+        if current == 1:
+            ant_directions[i] = (ant_directions[i] + 1) % DIRS.size()
+            grid[idx] = 0
+        else:
+            ant_directions[i] = (ant_directions[i] + DIRS.size() - 1) % DIRS.size()
+            grid[idx] = 1
+
+        var next := pos + DIRS[ant_directions[i]]
+        if edge_mode == EDGE_WRAP:
+            next = wrap_position(next)
+        elif edge_mode == EDGE_BOUNCE:
+            if next.x < 0 or next.x >= grid_size.x or next.y < 0 or next.y >= grid_size.y:
+                ant_directions[i] = (ant_directions[i] + 2) % DIRS.size()
+                next = pos + DIRS[ant_directions[i]]
+                next.x = clamp(next.x, 0, grid_size.x - 1)
+                next.y = clamp(next.y, 0, grid_size.y - 1)
+        elif edge_mode == EDGE_FALLOFF:
+            if next.x < 0 or next.x >= grid_size.x or next.y < 0 or next.y >= grid_size.y:
+                remove_indices.append(i)
+                continue
+        ants[i] = next
+
+    for j in range(remove_indices.size() - 1, -1, -1):
+        var idx := remove_indices[j]
+        ants.remove_at(idx)
+        ant_directions.remove_at(idx)
+        ant_colors.remove_at(idx)
+
+    ant_step_counter += 1
+    if gol_every_ant_steps > 0 and ant_step_counter % gol_every_ant_steps == 0:
+        step_game_of_life()
+
+func step_game_of_life() -> void:
+    var next_state := PackedByteArray()
+    next_state.resize(grid.size())
+    for y in range(grid_size.y):
+        for x in range(grid_size.x):
+            var alive := sample_cell(Vector2i(x, y))
+            var neighbors := 0
+            for dy in range(-1, 2):
+                for dx in range(-1, 2):
+                    if dx == 0 and dy == 0:
+                        continue
+                    neighbors += sample_cell(Vector2i(x + dx, y + dy))
+            var new_val := 0
+            if alive == 1:
+                if neighbors == 2 or neighbors == 3:
+                    new_val = 1
+                else:
+                    new_val = 0
+            else:
+                if neighbors == 3:
+                    new_val = 1
+                else:
+                    new_val = 0
+            next_state[y * grid_size.x + x] = new_val
+    grid = next_state
+
+func render_grid() -> void:
+    if grid_size.x <= 0 or grid_size.y <= 0:
+        return
+    var img := Image.create(grid_size.x * cell_size, grid_size.y * cell_size, false, Image.FORMAT_RGBA8)
+    var ant_map: Dictionary = {}
+    for i in range(ants.size()):
+        ant_map[ants[i]] = ant_colors[i]
+    for y in range(grid_size.y):
+        for x in range(grid_size.x):
+            var color: Color
+            if grid[y * grid_size.x + x] == 1:
+                color = alive_color
+            else:
+                color = dead_color
+            if ant_map.has(Vector2i(x, y)):
+                color = ant_map[Vector2i(x, y)]
+            for oy in range(cell_size):
+                for ox in range(cell_size):
+                    img.set_pixel(x * cell_size + ox, y * cell_size + oy, color)
+    var tex := ImageTexture.create_from_image(img)
+    grid_view.texture = tex
 
 func _process(delta: float) -> void:
-    production_accumulator += delta * float(autoclippers) * AUTOCLIPPER_RATE * (1.0 + clipper_rate_bonus)
-    while production_accumulator >= 1.0:
-        if not make_clip():
-            production_accumulator = 0.0
-            break
-        production_accumulator -= 1.0
-
-    update_demand(delta)
-    sales_accumulator += delta
-    if sales_accumulator >= 0.5:
-        process_sales(sales_accumulator)
-        sales_accumulator = 0.0
-
-    accumulate_operations(delta)
-
-    refresh_ui()
-
-func make_clip() -> bool:
-    if wire <= 0:
-        return false
-    wire -= 1
-    total_paperclips += 1
-    unsold_inventory += 1
-    return true
-
-func process_sales(elapsed: float) -> void:
-    if unsold_inventory <= 0:
+    if not ui_ready:
         return
-    demand_buffer += smoothed_demand * elapsed
-    var potential_sales: int = int(floor(demand_buffer))
-    demand_buffer -= float(potential_sales)
-    var actual_sales: int = min(unsold_inventory, potential_sales)
-    if actual_sales <= 0:
+    if is_paused and not step_requested:
         return
-    unsold_inventory -= actual_sales
-    total_sold += actual_sales
-    funds += float(actual_sales) * price
 
-func calculate_target_demand() -> float:
-    var base_demand: float = 0.8 + float(marketing_level) * 0.3 + demand_bonus
-    var price_factor: float = clamp(1.5 - price * 0.45 * price_sensitivity, 0.65, 1.9)
-    var safe_inventory: float = max(float(unsold_inventory) - 500.0, 0.0)
-    var inventory_pressure: float = clamp(1.0 - safe_inventory / 80000.0, 0.97, 1.0)
-    var sold_after_threshold: float = max(float(total_sold) - 1500000.0, 0.0)
-    var saturation_pressure: float = 1.0 - min(sold_after_threshold / 175000000.0, 0.25)
-    return max(0.15, base_demand * price_factor * inventory_pressure * saturation_pressure)
+    if not step_requested and global_rate > 0.0:
+        global_accumulator += delta
+        var global_interval := 1.0 / global_rate
+        if global_accumulator < global_interval:
+            return
+        global_accumulator -= global_interval
+    else:
+        global_accumulator = 0.0
 
-func update_demand(delta: float) -> void:
-    var target: float = calculate_target_demand()
-    var smoothing_factor: float = clamp(delta * 0.12, 0.0, 0.35)
-    smoothed_demand = lerpf(smoothed_demand, target, smoothing_factor)
+    var updated := false
 
-func adjust_price(amount: float) -> void:
-    price = clamp(price + amount, MIN_PRICE, MAX_PRICE)
-    price = snapped(price, 0.01)
+    updated = process_wolfram(delta) or updated
+    updated = process_ants(delta) or updated
+    updated = process_game_of_life(delta) or updated
 
-func _on_make_clip_pressed() -> void:
-    make_clip()
+    if step_requested:
+        if wolfram_enabled:
+            step_wolfram()
+            updated = true
+        if ants_enabled:
+            step_ants()
+            updated = true
+        if gol_enabled:
+            step_game_of_life()
+            updated = true
+        step_requested = false
 
-func _on_buy_wire_pressed() -> void:
-    if funds < WIRE_BASE_COST:
-        return
-    funds -= WIRE_BASE_COST
-    wire += wire_per_purchase
+    if updated:
+        render_grid()
 
-func _on_buy_marketing_pressed() -> void:
-    var cost: float = get_effective_marketing_cost()
-    if funds < cost:
-        return
-    funds -= cost
-    marketing_level += 1
-    marketing_cost = round(marketing_cost * 1.2 * 100.0) / 100.0
-
-func _on_buy_autoclipper_pressed() -> void:
-    if funds < autoclipper_cost:
-        return
-    funds -= autoclipper_cost
-    autoclippers += 1
-    autoclipper_cost = round(autoclipper_cost * 1.15 * 100.0) / 100.0
-
-func _on_buy_processor_pressed() -> void:
-    if funds < processor_cost:
-        return
-    funds -= processor_cost
-    processors += 1
-    processor_cost = round(processor_cost * 1.15 * 100.0) / 100.0
-
-func _on_buy_memory_pressed() -> void:
-    if funds < memory_cost:
-        return
-    funds -= memory_cost
-    memory_banks += 1
-    update_ops_capacity()
-    memory_cost = round(memory_cost * 1.18 * 100.0) / 100.0
-
-func format_currency(value: float) -> String:
-    return "$%.2f" % value
-
-func get_effective_marketing_cost() -> float:
-    return round(marketing_cost * (1.0 - marketing_discount) * 100.0) / 100.0
-
-func accumulate_operations(delta: float) -> void:
-    var ops_rate: float = float(processors) * (OPS_PER_PROCESSOR + float(memory_banks) * OPS_MEMORY_FACTOR)
-    ops_rate *= 1.0 + ops_rate_bonus
-    operations = min(operations + ops_rate * delta, float(ops_capacity))
-
-func update_ops_capacity() -> void:
-    ops_capacity = BASE_OPS_CAPACITY + ops_capacity_bonus + memory_banks * 150
-    operations = min(operations, float(ops_capacity))
-
-func _on_upgrade_pressed(key: String) -> void:
-    var upgrade: Upgrade = get_upgrade(key)
-    if upgrade.applied:
-        return
-    if operations < float(upgrade.ops_cost):
-        return
-    operations -= float(upgrade.ops_cost)
-    upgrade.applied = true
-    upgrade.effect.call()
-
-func get_upgrade(key: String) -> Upgrade:
-    for upgrade: Upgrade in upgrades:
-        if upgrade.key == key:
-            return upgrade
-    push_error("Unknown upgrade key: %s" % key)
-    return upgrades[0]
-
-func is_upgrade_unlocked(upgrade: Upgrade) -> bool:
-    if total_paperclips < upgrade.unlock_at_clips:
-        return false
-    if upgrade.prerequisite != "":
-        var prerequisite_upgrade: Upgrade = get_upgrade(upgrade.prerequisite)
-        if not prerequisite_upgrade.applied:
-            return false
-    return true
-
-func refresh_ui() -> void:
-    labels["total"].text = str(total_paperclips)
-    labels["inventory"].text = str(unsold_inventory)
-    labels["price"].text = format_currency(price)
-    labels["funds"].text = format_currency(funds)
-    labels["wire"].text = str(wire) + " m"
-
-    var clip_rate: float = float(autoclippers) * AUTOCLIPPER_RATE * (1.0 + clipper_rate_bonus)
-    if wire <= 0:
-        clip_rate = 0.0
-    labels["production"].text = "%.2f" % clip_rate
-    labels["marketing"].text = str(marketing_level)
-    labels["autoclippers"].text = str(autoclippers)
-
-    labels["demand"].text = "Demand: %.2f clips / sec" % smoothed_demand
-    labels["processors"].text = str(processors)
-    labels["memory"].text = str(memory_banks)
-    labels["ops"].text = "%.0f / %d ops" % [operations, ops_capacity]
-
-    var autoclipper_unlocked: bool = total_paperclips >= AUTOCLIPPER_UNLOCK
-    buttons["autoclipper"].visible = autoclipper_unlocked
-    buttons["make"].disabled = wire <= 0
-    buttons["wire"].text = "Buy wire (+" + str(wire_per_purchase) + "m) (" + format_currency(WIRE_BASE_COST) + ")"
-    buttons["wire"].disabled = funds < WIRE_BASE_COST
-
-    buttons["marketing"].text = "Launch marketing (" + format_currency(get_effective_marketing_cost()) + ")"
-    buttons["marketing"].disabled = funds < get_effective_marketing_cost()
-
-    buttons["autoclipper"].text = "Buy AutoClipper (" + format_currency(autoclipper_cost) + ")"
-    buttons["autoclipper"].disabled = funds < autoclipper_cost or wire <= 0
-
-    var computing_unlocked: bool = total_paperclips >= COMPUTING_UNLOCK
-    computing_panel.visible = computing_unlocked
-    buttons["processor"].visible = computing_unlocked
-    buttons["memory"].visible = computing_unlocked
-
-    buttons["processor"].text = "Buy processor (" + format_currency(processor_cost) + ")"
-    buttons["processor"].disabled = funds < processor_cost
-    buttons["memory"].text = "Buy memory (" + format_currency(memory_cost) + ")"
-    buttons["memory"].disabled = funds < memory_cost
-
-    for upgrade: Upgrade in upgrades:
-        var button: Button = upgrade_buttons[upgrade.key]
-        var unlocked: bool = is_upgrade_unlocked(upgrade)
-        button.visible = unlocked
-        button.disabled = upgrade.applied or (operations < float(upgrade.ops_cost)) or not unlocked
-        var label: String = "%s - %s" % [upgrade.label, upgrade.description]
-        label += " (" + str(upgrade.ops_cost) + " ops)"
-        if upgrade.applied:
-            label += " [purchased]"
-        button.text = label
-
-    buttons["price_down"].disabled = price <= MIN_PRICE
-    buttons["price_up"].disabled = price >= MAX_PRICE
+func _notification(what):
+    if what == NOTIFICATION_RESIZED:
+        update_grid_size()
+        render_grid()


### PR DESCRIPTION
## Summary
- add a global updates-per-second control to gate automata processing
- clear ants when wiping the grid and provide a dedicated clear ants action
- document the new controls in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c69111574832bbff6f70f5f4c8215)